### PR TITLE
Add indentation for boolean flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -244,9 +244,9 @@ fn bulid_detailed_row(runner: &RunnerDetails) -> Row<'static> {
         runner.description.to_string(),
         runner.ip_address.to_string(),
         runner.status.to_string(),
-        convert_str_flag(&runner.is_shared).to_string(),
-        convert_str_flag(&runner.active).to_string(),
-        convert_str_flag(&runner.online).to_string(),
+        format!("{}{}", " ".repeat(2), convert_str_flag(&runner.is_shared)),
+        format!("{}{}", " ".repeat(2), convert_str_flag(&runner.active)),
+        format!("{}{}", " ".repeat(2), convert_str_flag(&runner.online)),
         runner.tag_list.join(" | "),
     ]);
 


### PR DESCRIPTION
Before
<img width="527" alt="image" src="https://user-images.githubusercontent.com/24507532/162215693-5a2a1b29-432c-4e81-88fd-eebdcd3816a5.png">

After
<img width="528" alt="image" src="https://user-images.githubusercontent.com/24507532/162215516-9f950ba3-9e1e-468e-812d-1fa09e2b1208.png">


Formula for such indentation: `row_colmn_width / 2 - 1`.


P.S. It's better to have a global constraint variable from `Constraint::Length(6)` rather than hardcoding `repeat(2)`. Unfortunately I'm dummy in Rust refactoring.